### PR TITLE
securityhub: remove unreachable code after return

### DIFF
--- a/ocs_deploy/securityhub.py
+++ b/ocs_deploy/securityhub.py
@@ -23,18 +23,3 @@ class SecurityHubStack(Stack):
             description="ARN of the Security Hub",
         )
         return hub
-
-        standards_subscription = securityhub.CfnStandardsSubscription(
-            self,
-            "FoundationalSecurityBestPractices",
-            standards_arn=f"arn:aws:securityhub:{self.region}::standards/aws-foundational-security-best-practices/v/1.0.0",
-        )
-        # Ensure the subscription is created after Security Hub is enabled
-        standards_subscription.node.add_dependency(self.hub)
-        CfnOutput(
-            self,
-            self.config.make_name("SecurityHubStandardsSubscriptionArn"),
-            value=standards_subscription.attr_standards_subscription_arn,
-            description="ARN of the AWS Foundational Security Best Practices subscription",
-        )
-        return standards_subscription


### PR DESCRIPTION
Summary:
This PR removes the previously added but non-functional CfnStandardsSubscription block from the SecurityHubStack.

Details:
	The CfnStandardsSubscription block was originally added to enable the AWS Foundational Security Best Practices standard. However, it was not working as expected. To temporarily avoid a synth error, it was placed after a return statementmaking it unreachable at runtime.To keep the codebase clean and functional, the unreachable block has now been removed.

Note:
If standard subscription logic is required in the future, it will be properly implemented with the correct dependency handling and return structure.