### PR TITLE
Reduce prod costs: Fargate Spot, remove VPC endpoints, upgrade RDS

### DIFF
--- a/ocs_deploy/rds.py
+++ b/ocs_deploy/rds.py
@@ -67,9 +67,8 @@ class RdsStack(cdk.Stack):
             engine=rds.DatabaseInstanceEngine.postgres(
                 version=rds.PostgresEngineVersion.VER_16,
             ),
-            # db.t4g.small
             instance_type=ec2.InstanceType.of(
-                ec2.InstanceClass.T4G, ec2.InstanceSize.SMALL
+                ec2.InstanceClass.T4G, ec2.InstanceSize.MEDIUM
             ),
             allocated_storage=20,
             max_allocated_storage=100,

--- a/ocs_deploy/vpc.py
+++ b/ocs_deploy/vpc.py
@@ -42,19 +42,6 @@ class VpcStack(cdk.Stack):
 
         vpc.add_gateway_endpoint("S3", service=ec2.GatewayVpcEndpointAwsService.S3)
 
-        # Needed for ECS tasks (managed in Fargate) to pull images
-        vpc.add_interface_endpoint(
-            "EcsEndpoint", service=ec2.InterfaceVpcEndpointAwsService.ECS
-        )
-        # Needed for fargate to pull initial image from ECR
-        vpc.add_interface_endpoint(
-            "EcrEndpoint", service=ec2.InterfaceVpcEndpointAwsService.ECR
-        )
-        # TODO: Unclear if we need this
-        vpc.add_interface_endpoint(
-            "EcrDockerEndpoint", service=ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER
-        )
-
         self._setup_flow_logs(config, vpc)
 
         return vpc


### PR DESCRIPTION
## Summary
- **Fargate Spot for Celery workers**: 1 worker on standard Fargate (base capacity), remaining workers on Spot (~70% compute savings, ~$200-265/mo)
- **Remove redundant VPC interface endpoints**: ECS, ECR, and ECR Docker endpoints removed; traffic routes through existing NAT gateways (~$65/mo savings)
- **Upgrade RDS from db.t4g.small to db.t4g.medium**: Doubles RAM from 2GB to 4GB to reduce memory pressure with connection pooling (~$36/mo increase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)