### PR TITLE
Add EMAIL_CHANNEL_ALLOWED_DOMAINS env var to fargate tasks

### DIFF
--- a/ocs_deploy/config.py
+++ b/ocs_deploy/config.py
@@ -210,6 +210,7 @@ class OCSConfig:
             "WHATSAPP_S3_AUDIO_BUCKET": self.s3_whatsapp_audio_bucket,
             "SENTRY_ENVIRONMENT": self._config.get("SENTRY_ENVIRONMENT", "development"),
             "DJANGO_ALLOWED_HOSTS": self.allowed_hosts,
+            "EMAIL_CHANNEL_ALLOWED_DOMAINS": ",".join(self.all_inbound_domains),
             "SYSTEM_AGENT_MODELS_HIGH": self._config.get(
                 "SYSTEM_AGENT_MODELS_HIGH", ""
             ),


### PR DESCRIPTION
## Summary
- Adds `EMAIL_CHANNEL_ALLOWED_DOMAINS` to the shared Django/Celery env in `_get_common_env`, sourced from `all_inbound_domains` (comma-separated)
- Lets the Django app validate incoming emails against the same domain set already used for SES inbound routing, with no extra config to keep in sync

See https://github.com/dimagi/open-chat-studio/pull/3254

## Test plan
- [x] `uv run pytest ocs_deploy/tests/test_config.py` passes
- [ ] Verify env var appears on Django + Celery tasks after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)