### PR TITLE
feat: add HubSpot prelogin contact env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ EMAIL_INBOUND_DOMAINS=
 DJANGO_SERVER_EMAIL=noreply@openchatstudio.com
 DJANGO_DEFAULT_FROM_EMAIL=noreply@openchatstudio.com
 DOMAIN_NAME=
+
+# HubSpot prelogin contact form (optional)
+HUBSPOT_FORM_PORTAL_ID=
+HUBSPOT_FORM_ID=
+PRELOGIN_CONTACT_EMAIL=
 # Optional: host serving anymail's SES inbound webhook. Defaults to DOMAIN_NAME
 # when unset. Set this only if the webhook endpoint lives on a different host
 # than the apex domain (e.g. during a domain migration).

--- a/ocs_deploy/config.py
+++ b/ocs_deploy/config.py
@@ -226,6 +226,9 @@ class OCSConfig:
             "TASKBADGER_PROJECT",
             "DJANGO_SERVER_EMAIL",
             "DJANGO_DEFAULT_FROM_EMAIL",
+            "HUBSPOT_FORM_PORTAL_ID",
+            "HUBSPOT_FORM_ID",
+            "PRELOGIN_CONTACT_EMAIL",
         ]
         for key in optional:
             if value := self._config.get(key):


### PR DESCRIPTION
Wires `HUBSPOT_FORM_PORTAL_ID`, `HUBSPOT_FORM_ID`, and `PRELOGIN_CONTACT_EMAIL` through to the Django/Celery containers as optional, non-secret env vars (the prelogin contact form needs them at runtime).

Note for deploy: the real prod values live in `.env.prod`, which is gitignored — they must be set there separately for this to take effect. Only the code wiring and the `.env.example` template are in this PR.