### PR TITLE
add TEAM_METADATA_FIELDS env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ DOMAIN_NAME=
 HUBSPOT_FORM_PORTAL_ID=
 HUBSPOT_FORM_ID=
 PRELOGIN_CONTACT_EMAIL=
+
+# Optional: JSON array of team metadata field definitions, loaded via json.loads.
+# Do NOT wrap the value in outer quotes — dotenv reads it as a raw literal.
+TEAM_METADATA_FIELDS=[{"key":"division","label":"Dimagi Division Name"},{"key":"owner","label":"Dimagi Owner"}]
 # Optional: host serving anymail's SES inbound webhook. Defaults to DOMAIN_NAME
 # when unset. Set this only if the webhook endpoint lives on a different host
 # than the apex domain (e.g. during a domain migration).

--- a/ocs_deploy/config.py
+++ b/ocs_deploy/config.py
@@ -230,6 +230,7 @@ class OCSConfig:
             "HUBSPOT_FORM_PORTAL_ID",
             "HUBSPOT_FORM_ID",
             "PRELOGIN_CONTACT_EMAIL",
+            "TEAM_METADATA_FIELDS",
         ]
         for key in optional:
             if value := self._config.get(key):


### PR DESCRIPTION
Adds `TEAM_METADATA_FIELDS` as an optional env var for the Django and Celery processes. Value is a JSON array loaded via `json.loads`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)